### PR TITLE
Add getSockets to Namespace and Room

### DIFF
--- a/socket-io/src/main/java/com/codeminders/socketio/server/Namespace.java
+++ b/socket-io/src/main/java/com/codeminders/socketio/server/Namespace.java
@@ -131,4 +131,9 @@ public class Namespace implements Outbound, ConnectionListener, DisconnectListen
                 room.leave(socket);
         }
     }
+
+    public Iterable<Socket> getSockets()
+    {
+        return sockets;
+    }
 }

--- a/socket-io/src/main/java/com/codeminders/socketio/server/Room.java
+++ b/socket-io/src/main/java/com/codeminders/socketio/server/Room.java
@@ -86,4 +86,9 @@ public class Room implements Outbound
                 socket.emit(name, args);
         }
     }
+
+    public Iterable<Socket> getSockets()
+    {
+        return sockets;
+    }
 }


### PR DESCRIPTION
Adding getters for sockets allows iteration of connected sockets and selectively send messages to those sockets.

I have some security requirements that I only send message to specific users based on their properties. Similar to this question asked [here](https://stackoverflow.com/questions/18654173/emiting-with-exclusion-in-socket-io). This PR allows me to get at the list of currently connected clients so that I can pick and choose which ones to send to.