### PR TITLE
Add HttpSession to socket.io session

### DIFF
--- a/socket-io/src/main/java/com/codeminders/socketio/server/Session.java
+++ b/socket-io/src/main/java/com/codeminders/socketio/server/Session.java
@@ -30,6 +30,7 @@ import com.codeminders.socketio.protocol.*;
 import com.codeminders.socketio.common.ConnectionState;
 import com.codeminders.socketio.common.DisconnectReason;
 
+import javax.servlet.http.HttpSession;
 import java.io.InputStream;
 import java.util.*;
 import java.util.concurrent.*;
@@ -51,6 +52,7 @@ public class Session implements DisconnectListener
 
     private final SocketIOManager socketIOManager;
     private final String          sessionId;
+    private final HttpSession     httpSession;
     private final Map<String, Object> attributes = new ConcurrentHashMap<>();
 
     private Map<String, Socket> sockets = new LinkedHashMap<>(); // namespace, socket
@@ -69,12 +71,13 @@ public class Session implements DisconnectListener
     private int                       packet_id     = 0; // packet id. used for requesting ACK
     private Map<Integer, ACKListener> ack_listeners = new LinkedHashMap<>(); // packetid, listener
 
-    Session(SocketIOManager socketIOManager, String sessionId)
+    Session(SocketIOManager socketIOManager, String sessionId, HttpSession httpSession)
     {
         assert (socketIOManager != null);
 
         this.socketIOManager = socketIOManager;
         this.sessionId = sessionId;
+        this.httpSession = httpSession;
     }
 
     public Socket createSocket(String ns)
@@ -495,5 +498,10 @@ public class Session implements DisconnectListener
             if (LOGGER.isLoggable(Level.WARNING))
                 LOGGER.log(Level.WARNING, "Cannot send NOOP packet while upgrading the transport", e);
         }
+    }
+
+    public HttpSession getHttpSession()
+    {
+        return httpSession;
     }
 }

--- a/socket-io/src/main/java/com/codeminders/socketio/server/SocketIOManager.java
+++ b/socket-io/src/main/java/com/codeminders/socketio/server/SocketIOManager.java
@@ -25,6 +25,7 @@
  */
 package com.codeminders.socketio.server;
 
+import javax.servlet.http.HttpSession;
 import java.util.Map;
 import java.util.concurrent.*;
 
@@ -78,11 +79,24 @@ public final class SocketIOManager
     /**
      * Creates new session
      *
+     * @deprecated use {@link SocketIOManager#createSession(HttpSession)}
      * @return new session
      */
+    @Deprecated
     public Session createSession()
     {
-        Session session = new Session(this, generateSessionId());
+        return createSession(null);
+    }
+
+    /**
+     * Creates new session
+     *
+     * @param httpSession The HTTP session of the connecting client
+     * @return new session
+     */
+    public Session createSession(HttpSession httpSession)
+    {
+        Session session = new Session(this, generateSessionId(), httpSession);
         sessions.put(session.getSessionId(), session);
         return session;
     }

--- a/socket-io/src/main/java/com/codeminders/socketio/server/transport/AbstractTransport.java
+++ b/socket-io/src/main/java/com/codeminders/socketio/server/transport/AbstractTransport.java
@@ -29,6 +29,7 @@ import javax.servlet.ServletConfig;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
 
 /**
  * @author Alexander Sova (bird@codeminders.com)
@@ -72,7 +73,7 @@ public abstract class AbstractTransport implements Transport
             session = sessionManager.getSession(sessionId);
 
         if(session == null)
-            return createConnection(sessionManager.createSession());
+            return createConnection(sessionManager.createSession(request.getSession()));
 
         TransportConnection activeConnection = session.getConnection();
 

--- a/socket-io/src/main/java/com/codeminders/socketio/server/transport/websocket/WebsocketTransportConnection.java
+++ b/socket-io/src/main/java/com/codeminders/socketio/server/transport/websocket/WebsocketTransportConnection.java
@@ -35,6 +35,7 @@ import com.google.common.io.ByteStreams;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 import javax.websocket.*;
 import javax.websocket.server.HandshakeRequest;
 import javax.websocket.server.ServerEndpoint;
@@ -295,6 +296,21 @@ public final class WebsocketTransportConnection extends AbstractTransportConnect
         return values.get(0);
     }
 
+    private HttpSession getHttpSession(javax.websocket.Session session)
+    {
+        HandshakeRequest handshake = (HandshakeRequest)
+                session.getUserProperties().get(HandshakeRequest.class.getName());
+        if (handshake == null)
+        {
+            return null;
+        }
+        if (!(handshake.getHttpSession() instanceof HttpSession))
+        {
+            return null;
+        }
+        return (HttpSession) handshake.getHttpSession();
+    }
+
     /**
      * Initializes socket.io session
      * @param session
@@ -308,7 +324,8 @@ public final class WebsocketTransportConnection extends AbstractTransportConnect
             sess = SocketIOManager.getInstance().getSession(sessionId);
         }
         if (sess == null) {
-            sess = SocketIOManager.getInstance().createSession();
+            HttpSession httpSession = getHttpSession(session);
+            sess = SocketIOManager.getInstance().createSession(httpSession);
         }
         setSession(sess);
     }


### PR DESCRIPTION
I needed a way to get access to what user a socket is attached to using their HttpSession.  The problem is when using websockets `javax.websocket.Session` doesn't have access to `HttpServletRequest` which means `com.codeminders.socketio.server.transport.AbstractTransportConnection#setRequest` never gets called so I can't get it from there.