### PR TITLE
Fixed support of binary values in Map

### DIFF
--- a/socket-io/src/main/java/com/codeminders/socketio/protocol/SocketIOProtocol.java
+++ b/socket-io/src/main/java/com/codeminders/socketio/protocol/SocketIOProtocol.java
@@ -364,7 +364,7 @@ public final class SocketIOProtocol
             Set<Map.Entry> entries = ((Map) json).entrySet();
 
             for (Map.Entry e : entries)
-                map.put(e.getKey(), extractBinaryObjects(e, attachments));
+                map.put(e.getKey(), extractBinaryObjects(e.getValue(), attachments));
 
             return map;
         }


### PR DESCRIPTION
There was a problem with encoding of Map which contains binary values like:
map.put("name", "string");
map.put("name1", ByteArrayInputStream(blabla));

The JSON was like:
{"name": {"name","string"}, ...}

but should be 
{"name": "string", ...}