### PR TITLE
add timeout to the call that gets first EngineIOPacket in XHRTranspor…

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.codeminders.socketio</groupId>
         <artifactId>socketio-server</artifactId>
-        <version>1.0.2-a</version>
+        <version>1.0.2-b</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/core/src/main/java/com/codeminders/socketio/server/transport/XHRTransportConnection.java
+++ b/core/src/main/java/com/codeminders/socketio/server/transport/XHRTransportConnection.java
@@ -17,6 +17,7 @@ import java.io.OutputStream;
 
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -96,7 +97,7 @@ public class XHRTransportConnection extends AbstractTransportConnection
             {
 
                 OutputStream os = response.getOutputStream();
-                for (EngineIOPacket packet = packets.take(); packet != null; packet = packets.poll())
+                for (EngineIOPacket packet = packets.poll(3, TimeUnit.MINUTES); packet != null; packet = packets.poll())
                 {
                     if(done)
                         break;

--- a/extension/jetty/pom.xml
+++ b/extension/jetty/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.codeminders.socketio.extension</groupId>
         <artifactId>socketio-server-extension</artifactId>
-        <version>1.0.2-a</version>
+        <version>1.0.2-b</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/extension/pom.xml
+++ b/extension/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.codeminders.socketio</groupId>
         <artifactId>socketio-server</artifactId>
-        <version>1.0.2-a</version>
+        <version>1.0.2-b</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.codeminders.socketio</groupId>
     <artifactId>socketio-server</artifactId>
-    <version>1.0.2-a</version>
+    <version>1.0.2-b</version>
     <packaging>pom</packaging>
 
     <name>Socket.IO Java Server</name>

--- a/samples/chat/pom.xml
+++ b/samples/chat/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.codeminders.socketio.sample</groupId>
         <artifactId>socketio-server-sample</artifactId>
-        <version>1.0.2-a</version>
+        <version>1.0.2-b</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.codeminders.socketio</groupId>
         <artifactId>socketio-server</artifactId>
-        <version>1.0.2-a</version>
+        <version>1.0.2-b</version>
         <relativePath>..</relativePath>
     </parent>
 


### PR DESCRIPTION
…tConnection.handle() and set version to 1.0.2-b


basically replaced take() with poll() with timeout. I think 3 min is excessive, but leave it up to you to decide. I do not have a clear understanding of how do we end up in the situation where the client has already closed connection by the time of the call to take() is made, so the socket is in CLOSE_WAIT state and take() never returns. See my emails for more detailed analysis.
