### PR TITLE
Fix incorrect parsing of multiple packets in payload

### DIFF
--- a/socket-io/src/main/java/com/codeminders/socketio/protocol/EngineIOProtocol.java
+++ b/socket-io/src/main/java/com/codeminders/socketio/protocol/EngineIOProtocol.java
@@ -215,8 +215,9 @@ public final class EngineIOProtocol
         {
             int len = decodePacketLength(payload, pos);
             EngineIOPacket.Type type = decodePacketType(payload, pos);
-            String data = payload.substring(pos.getIndex(), pos.getIndex() + len-1 );
-            pos.setIndex(pos.getIndex() + 1 + len);
+            int prefixLength = Integer.toString(len).length() + 2;
+            String data = payload.substring(pos.getIndex() - prefixLength, pos.getIndex() + len - 1);
+            pos.setIndex(pos.getIndex() + 1 + len - 2);
 
             switch (type)
             {


### PR DESCRIPTION
Current implementation of payload parsing fails when receive payload with multiple packets in it. This commit fix it.

Example (slightly synthetic, but show the idea):
Receive payload `10:40/stream,1:227:42/stream,["SET_STREAM_ID"]`

Expected behaviour:
Process all 3 packets
- Message `0/stream`
- Ping
- Message `2/stream,["SET_STREAM_ID"]

Actual behaviour:
Exception SocketIOProtocolException with message "No packet length defined" thrown