### PR TITLE
Fix incorrect parsing of multiple packets in payload

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,14 @@
                 <role>contributor</role>
             </roles>
         </contributor>
+        <contributor>
+            <name>SQReder</name>
+            <email>sqreder@gmail.com</email>
+            <timezone>+3</timezone>
+            <roles>
+                <role>contributor</role>
+            </roles>
+        </contributor>
     </contributors>
 
     <licenses>

--- a/socket-io/pom.xml
+++ b/socket-io/pom.xml
@@ -45,6 +45,24 @@
             <version>1.1</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.2.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.10</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.10.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/socket-io/pom.xml
+++ b/socket-io/pom.xml
@@ -46,12 +46,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <version>5.2.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.10</version>

--- a/socket-io/src/main/java/com/codeminders/socketio/protocol/EngineIOPacket.java
+++ b/socket-io/src/main/java/com/codeminders/socketio/protocol/EngineIOPacket.java
@@ -23,6 +23,7 @@
 package com.codeminders.socketio.protocol;
 
 import java.io.InputStream;
+import java.util.Objects;
 
 /**
  * @author Alexander Sova (bird@codeminders.com)
@@ -104,5 +105,31 @@ public class EngineIOPacket
     public EngineIOPacket(Type type)
     {
         this(type, "");
+    }
+
+    @Override
+    public String toString()
+    {
+        return "EngineIOPacket{" +
+                "type=" + type +
+                ", textData='" + textData + '\'' +
+                ", binaryData=" + binaryData +
+                '}';
+    }
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        EngineIOPacket that = (EngineIOPacket) o;
+        return type == that.type &&
+                Objects.equals(textData, that.textData) &&
+                Objects.equals(binaryData, that.binaryData);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(type, textData, binaryData);
     }
 }

--- a/socket-io/src/main/java/com/codeminders/socketio/protocol/EngineIOProtocol.java
+++ b/socket-io/src/main/java/com/codeminders/socketio/protocol/EngineIOProtocol.java
@@ -215,8 +215,8 @@ public final class EngineIOProtocol
         {
             int len = decodePacketLength(payload, pos);
             EngineIOPacket.Type type = decodePacketType(payload, pos);
-            String data = payload.substring(pos.getIndex(), pos.getIndex() + len-1 );
-            pos.setIndex(pos.getIndex() + 1 + len);
+            String data = payload.substring(pos.getIndex(), pos.getIndex() + len - 1);
+            pos.setIndex(pos.getIndex() - 1 + len);
 
             switch (type)
             {

--- a/socket-io/src/test/java/com/codeminders/socketio/protocol/EngineIOProtocolTest.java
+++ b/socket-io/src/test/java/com/codeminders/socketio/protocol/EngineIOProtocolTest.java
@@ -1,0 +1,38 @@
+package com.codeminders.socketio.protocol;
+
+import com.codeminders.socketio.server.SocketIOProtocolException;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EngineIOProtocolTest {
+    @Test
+    void decodeMultiPayload()
+            throws SocketIOProtocolException, StringIndexOutOfBoundsException
+    {
+        String payload = "10:40/stream,1:227:42/stream,[\"SET_STREAM_ID\"]1:1";
+        List<EngineIOPacket> expected = new ArrayList<>();
+        expected.add(new EngineIOPacket(EngineIOPacket.Type.MESSAGE, "0/stream,"));
+        expected.add(new EngineIOPacket(EngineIOPacket.Type.PING, ""));
+        expected.add(new EngineIOPacket(EngineIOPacket.Type.MESSAGE, "2/stream,[\"SET_STREAM_ID\"]"));
+        expected.add(new EngineIOPacket(EngineIOPacket.Type.CLOSE, ""));
+
+        List<EngineIOPacket> result = EngineIOProtocol.decodePayload(payload);
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    void decodeSimplePayload()
+            throws SocketIOProtocolException
+    {
+        String payload = "10:40/stream,";
+        List<EngineIOPacket> expected = new ArrayList<>();
+        expected.add(new EngineIOPacket(EngineIOPacket.Type.MESSAGE, "0/stream,"));
+
+        List<EngineIOPacket> result = EngineIOProtocol.decodePayload(payload);
+        assertThat(result).isEqualTo(expected);
+    }
+}

--- a/socket-io/src/test/java/com/codeminders/socketio/protocol/EngineIOProtocolTest.java
+++ b/socket-io/src/test/java/com/codeminders/socketio/protocol/EngineIOProtocolTest.java
@@ -1,16 +1,16 @@
 package com.codeminders.socketio.protocol;
 
 import com.codeminders.socketio.server.SocketIOProtocolException;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class EngineIOProtocolTest {
+public class EngineIOProtocolTest {
     @Test
-    void decodeMultiPayload()
+    public void decodeMultiPayload()
             throws SocketIOProtocolException, StringIndexOutOfBoundsException
     {
         String payload = "10:40/stream,1:227:42/stream,[\"SET_STREAM_ID\"]1:1";
@@ -25,7 +25,7 @@ class EngineIOProtocolTest {
     }
 
     @Test
-    void decodeSimplePayload()
+    public void decodeSimplePayload()
             throws SocketIOProtocolException
     {
         String payload = "10:40/stream,";


### PR DESCRIPTION
Current implementation of payload parsing fails when receive payload with multiple packets in it. This pr fix it, and contain related tests

Example (slightly synthetic, but show the idea):
Receive payload 10:40/stream,1:227:42/stream,["SET_STREAM_ID"]

Expected behaviour:
Process all 3 packets

Message 0/stream
Ping
Message `2/stream,["SET_STREAM_ID"]
Actual behaviour:
Exception SocketIOProtocolException with message "No packet length defined" thrown